### PR TITLE
Individual workflow steps

### DIFF
--- a/util.py
+++ b/util.py
@@ -1,0 +1,123 @@
+import datetime
+import json
+
+from typing import Optional, List, Dict, Any
+
+import streamlit as st
+from boltons.strutils import slugify
+
+from github import Github, UnknownObjectException
+from github.ContentFile import ContentFile
+from github.InputGitAuthor import InputGitAuthor
+
+from kiara_plugin.streamlit.modules import DummyModuleConfig
+
+
+REPO_NAME = st.secrets.get("github_repo_path")
+GITHUB_API_KEY = st.secrets.get("github_api_key")
+
+COMMITTER = InputGitAuthor("kiara-streamlit", "streamlit@example.com")
+# TODO are there better details we could use here ^^?
+
+RESEARCH_QUESTIONS_DELIMITER = "\n## Research Questions\n"
+
+github_client = Github(GITHUB_API_KEY)
+repo = github_client.get_repo(REPO_NAME)
+
+
+def fetch_existing_file_from_github(path: str) -> Optional[ContentFile]:
+    try:
+        file = repo.get_contents(path)
+    except UnknownObjectException:
+        return None
+    return file
+
+
+def write_existing_pipeline_data_to_state(data: Dict[Any, Any]) -> None:
+    docs = f'{data["doc"]["description"]}\n{data["doc"]["doc"]}'.split(
+        RESEARCH_QUESTIONS_DELIMITER
+    )
+    st.session_state.workflow_description = docs[0]
+    if len(docs) > 1:
+        st.session_state.workflow_research = docs[1]
+
+    for i in range(len(data["steps"])):
+        step_data = data["steps"][i]["module_config"]
+        st.session_state["steps"][i] = {
+            "title": step_data["title"].replace("_", " "),
+            "desc": step_data["desc"],
+            "inputs": step_data["inputs_schema"]["default"]["doc"],
+            "outputs": step_data["outputs_schema"]["default"]["doc"],
+        }
+
+
+def state_steps_to_module_config() -> List[DummyModuleConfig]:
+    steps_config = []
+    for s in st.session_state.steps:
+        step_data = st.session_state.steps[s]
+        step_example = DummyModuleConfig(
+            title=slugify(step_data["title"]),
+            desc=step_data["desc"],
+            inputs_schema={
+                "default": {
+                    "type": "any",
+                    "optional": "true",
+                    "doc": step_data["inputs"],
+                },
+            },
+            outputs_schema={
+                "default": {
+                    "type": "any",
+                    "optional": "true",
+                    "doc": step_data["outputs"],
+                },
+            },
+        )
+
+        steps_config.append(step_example)
+    return steps_config
+
+
+def write_file_to_github(path: str, data) -> None:
+    existing_file = fetch_existing_file_from_github(path)
+    if existing_file:
+        repo.update_file(
+            path=existing_file.path,
+            message=f"update data {datetime.datetime.utcnow()}",
+            content=data,
+            sha=existing_file.sha,
+            branch="main",
+            committer=COMMITTER,
+            author=COMMITTER,
+        )
+    else:
+        repo.create_file(
+            path,
+            message="create workflow",
+            content=data,
+            branch="main",
+            committer=COMMITTER,
+            author=COMMITTER,
+        )
+
+
+def load_and_parse_file(filepath):
+    workflow_file = fetch_existing_file_from_github(filepath)
+    if workflow_file:
+        existing_data = json.loads(workflow_file.decoded_content.decode("utf-8"))
+        write_existing_pipeline_data_to_state(existing_data)
+        st.success("Loaded existing workflow")
+    else:
+        st.warning("No saved workflow found")
+
+
+def serialize_workflow_to_github(filepath):
+    pc = DummyModuleConfig.create_pipeline_config(
+        st.session_state["workflow_title"],
+        f"{st.session_state['workflow_description']}{RESEARCH_QUESTIONS_DELIMITER}{st.session_state['workflow_research']}",
+        st.session_state["contact_email"],
+        *state_steps_to_module_config(),
+    )
+    # st.kiara.pipeline_graph(pc) #  TODO connect step input to previous step output in order to make the graph useful?
+    write_file_to_github(filepath, json.dumps(pc.dict(), indent=2))
+    # TODO is there a way to exclude some of the duplicated info about steps here?

--- a/workflows.py
+++ b/workflows.py
@@ -1,146 +1,114 @@
 # -*- coding: utf-8 -*-
-import datetime
-import json
 import time
-from typing import Optional
 
 import streamlit as st
 from boltons.strutils import slugify
 
-# pip install PyGithub
-from github import Github, UnknownObjectException
-from github.ContentFile import ContentFile
-from github.InputGitAuthor import InputGitAuthor
 from kiara.api import KiaraAPI
 
 import kiara_plugin.streamlit as kst
-from kiara_plugin.streamlit.modules import DummyModuleConfig
 
-# Write a secrets file that looks like
-# github_api_key = "ghp_XXXXXXXXXXXXXX"
-# ^^ a personal access token with at least repo:write permissions on the repo below
-# github_repo_path = "caro401/kiara-workflow-test"
-REPO_NAME = st.secrets.get("github_repo_path")
-GITHUB_API_KEY = st.secrets.get("github_api_key")
+from util import load_and_parse_file, serialize_workflow_to_github
 
-COMMITTER = InputGitAuthor("kiara-streamlit", "streamlit@example.com")
-# TODO are there better details we could use here ^^?
-
-github_client = Github(GITHUB_API_KEY)
-repo = github_client.get_repo(REPO_NAME)
 
 kst.init()
 
-
-def fetch_existing_file_from_github(path: str) -> Optional[ContentFile]:
-    try:
-        file = repo.get_contents(path)
-    except UnknownObjectException:
-        return None
-    return file
-
-
-def write_file_to_github(path: str, data) -> None:
-    existing_file = fetch_existing_file_from_github(path)
-    if existing_file:
-        repo.update_file(
-            path=existing_file.path,
-            message=f"update data {datetime.datetime.utcnow()}",
-            content=data,
-            sha=existing_file.sha,
-            branch="main",
-            committer=COMMITTER,
-            author=COMMITTER,
-        )
-    else:
-        repo.create_file(
-            path,
-            message="create workflow",
-            content=data,
-            branch="main",
-            committer=COMMITTER,
-            author=COMMITTER,
-        )
-
-
 api: KiaraAPI = st.kiara.api
 
-# example of how to do introspection of kiara environment
-# data_types = api.list_data_type_names()
-# st.selectbox("Select data type", data_types, key="data_type")
-# ops = api.list_operation_ids()
-# op = st.selectbox("Select operations", ops, key="ops")
-# st.kiara.item_info(op)
+if "steps" in st.session_state.keys():
+    steps = st.session_state["steps"]
+else:
+    steps = {}
+    st.session_state["steps"] = steps
 
-st.write("# Kiara workflow form")
-st.error(
-    "TODO: explain what Kiara is and give a link to docs, explain what we mean by a workflow."
-)
+st.write("# Kiara workflow collection")
+# TODO: explain what Kiara is and give a link to docs, explain what we mean by a workflow.
+
 st.write(
-    "Please tell us your email address to help us save and identify your workflows. We may get in touch for "
-    "follow-up questions, but we won't share your data at all."
+    "Please tell us your email address to help us save and identify your workflows."
 )
-contact_email = st.text_input("Email address")
+contact_email = st.text_input("Email address", key="contact_email")
 workflow_title = st.text_input(
     "Short title for your workflow",
+    key="workflow_title",
     placeholder="Topic modelling in Italian newspaper articles",
 )
 
-placeholder = st.empty()
-placeholder.info("Please enter your email and workflow title, then press enter.")
-if workflow_title and contact_email:
-    workflow_path = f"{contact_email}/{slugify(workflow_title)}.json"
+if not (workflow_title and contact_email):
+    st.info("Please enter your email and workflow title, then press enter.")
+else:
+    workflow_path = f"{contact_email}/{slugify(workflow_title)}/pipeline.json"
 
-    if "workflow_description" not in st.session_state:
-        placeholder.write("Looking for existing workflow data")
-        workflow_file = fetch_existing_file_from_github(workflow_path)
-        if workflow_file:
-            existing_data = json.loads(workflow_file.decoded_content.decode("utf-8"))
-            st.session_state.workflow_description = existing_data["doc"]["description"]
+    edit = st.button("load existing workflow for editing?")
+    if edit:
+        load_and_parse_file(workflow_path)
 
-    with placeholder.container():
-        workflow_description = st.text_area(
-            "Describe your workflow, in as much detail as you can",
-            key="workflow_description",
-            height=100,
+    st.text_area(
+        "Describe what your workflow achieves",
+        key="workflow_description",
+        height=100,
+        placeholder="Performing text analysis tasks on a corpus of documents",
+    )
+    st.text_area(
+        "What research questions does this workflow could help with?",
+        key="workflow_research",
+        height=100,
+    )
+
+    st.write("## Workflow steps")
+    st.write("Describe the individual steps you do in your workflow at the moment.")
+
+    # TODO give example steps in an expander and/or placeholders here?
+
+    for idx, step in steps.items():
+        title, desc, inputs, outputs = (
+            step["title"],
+            step["desc"],
+            step["inputs"],
+            step["outputs"],
         )
-        with st.expander("What should I write here?"):
-            st.write(
-                """You could (but don't have to) include things like: 
-- What is the research question you are working on with the data you produce from this workflow? 
-- Are there any special concepts or details of your research domain that are relevant to this workflow?
-- Where does your input data come from, what format is it in and how large is it?
-- What are the steps in your workflow, what kind of tasks do you do at each step? 
-- Who currently does these tasks, what tools or software do you use?
-- What is the format of the data you get at the end of your workflow? What do you do next with this data?
-- Is anything particularly difficult, time-consuming or annoying in your workflow?
-
-Don't worry if you don't know, or don't want to share, any of these things. 
-Any information you can give is useful and will help guide the Kiara roadmap.
-"""
-            )
-
-        # TODO collect individual step information
-        # step_details = st.button('Add internal step')
-        # if step_details:
-        #     st.write('## some steps here')
-        # do some caching here
-        # req1 = st.kiara.step_requirements(key="req1")
-        # req2 = st.kiara.step_requirements(key="req2")
-
-        create = st.button("Save workflow")
-        if create:
-            pc = DummyModuleConfig.create_pipeline_config(
-                workflow_title, workflow_description, contact_email
-            )
-            # st.kiara.pipeline_graph(pc)
-            write_file_to_github(workflow_path, pc.json())
-
-            toast = st.empty()
-            toast.success("Saved workflow")
-            time.sleep(3)
-            toast.write("")
-
-        st.warning(
-            "Don't refresh the page or close this tab until you've saved your workflow!"
+        st.write(f"### Step {idx + 1}")
+        steps[idx]["title"] = st.text_input(
+            "What does this step do?",
+            value=title,
+            key=f"title_step_{idx}",
+            placeholder="Load network data into a Python data structure",
         )
+        steps[idx]["inputs"] = step_input = st.text_area(
+            "What are the inputs for this step?",
+            value=inputs,
+            key=f"inputs_step_{idx}",
+            placeholder="Network data from journals, stored in 3 CSV files, which come from...",
+        )
+        steps[idx]["outputs"] = step_output = st.text_area(
+            "What are the outputs of this step?",
+            value=outputs,
+            key=f"outputs_step_{idx}",
+            placeholder="A networkX graph structure from ",
+        )
+        steps[idx]["desc"] = st.text_area(
+            "Any technical details about how you do this step currently? (optional)",
+            value=desc,
+            key=f"desc_step_{idx}",
+            placeholder="What existing software or packages do you use?",
+        )
+
+    add_step = st.button("Add step")
+    if add_step:
+        new_step_id = len(steps.keys())
+        steps[new_step_id] = {"title": "", "desc": "", "inputs": "", "outputs": ""}
+        st.write(st.session_state)
+        st.experimental_rerun()
+
+    create = st.button("Save workflow", type="primary")
+    if create:
+        serialize_workflow_to_github(workflow_path)
+        st.write(st.session_state)
+        toast = st.empty()
+        toast.success("Saved workflow")
+        time.sleep(3)
+        toast.write("")
+
+    st.warning(
+        "Don't refresh the page or close this tab until you've saved your workflow!"
+    )


### PR DESCRIPTION
This includes a bunch of changes (sorry!) including

- remove large red todo comment from the top of the streamlit output
- add a button to load a workflow you've already made for editing (rather than asking github every time you run the file)
- Separate asking general questions about what the workflow does and what research questions it answers
- Allow users to add details about each individual step in the workflow
- write out a pipeline.json file including generic steps

I've split functions for parsing state into and out of pipeline files, and interacting with github into a separate file to make the streamlit UI code easier to follow - hopefully that still works on Streamlit cloud?
