### PR TITLE
Add input data files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 venv
 .streamlit
 .idea
+__pycache__

--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@ github_api_key = "github_pat_XXXXXXXXXX"
 
 `github_repo_path` is where the streamlit app will read and write responses.
 
-`github_api_key` is a GitHub [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with permissions to read and write files in the repo you specified in `github_repo_path`.
+`github_api_key` is a GitHub [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token), created for the account/organization which owns the repo you specified in `github_repo_path`, and with permissions to read and write files in that repo .
 
 To run the app, install the requirements from `requirements.txt`, then run `streamlit run workflows.py`

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ kiara_plugin.onboarding
 git+https://github.com/DHARPA-project/kiara_plugin.streamlit@develop
 boltons
 PyGithub
+githublfs

--- a/util.py
+++ b/util.py
@@ -15,7 +15,7 @@ from kiara_plugin.streamlit.modules import DummyModuleConfig
 
 REPO_NAME = st.secrets.get("github_repo_path")
 GITHUB_API_KEY = st.secrets.get("github_api_key")
-
+BRANCH = "main"
 COMMITTER = InputGitAuthor("kiara-streamlit", "streamlit@example.com")
 # TODO are there better details we could use here ^^?
 
@@ -86,7 +86,7 @@ def write_file_to_github(path: str, data) -> None:
             message=f"update data {datetime.datetime.utcnow()}",
             content=data,
             sha=existing_file.sha,
-            branch="main",
+            branch=BRANCH,
             committer=COMMITTER,
             author=COMMITTER,
         )
@@ -95,7 +95,7 @@ def write_file_to_github(path: str, data) -> None:
             path,
             message="create workflow",
             content=data,
-            branch="main",
+            branch=BRANCH,
             committer=COMMITTER,
             author=COMMITTER,
         )
@@ -111,7 +111,7 @@ def load_and_parse_file(filepath):
         st.warning("No saved workflow found")
 
 
-def serialize_workflow_to_github(filepath):
+def serialize_workflow_to_github(filepath: str):
     pc = DummyModuleConfig.create_pipeline_config(
         st.session_state["workflow_title"],
         f"{st.session_state['workflow_description']}{RESEARCH_QUESTIONS_DELIMITER}{st.session_state['workflow_research']}",

--- a/util.py
+++ b/util.py
@@ -10,6 +10,7 @@ from github import Github, UnknownObjectException
 from github.ContentFile import ContentFile
 from github.InputGitAuthor import InputGitAuthor
 from githublfs import commit_lfs_file
+from kiara.models.module.pipeline import PipelineConfig
 from streamlit.elements.file_uploader import SomeUploadedFiles
 
 from kiara_plugin.streamlit.modules import DummyModuleConfig
@@ -22,12 +23,14 @@ COMMITTER = InputGitAuthor("kiara-streamlit", "streamlit@example.com")
 # TODO are there better details we could use here ^^?
 
 RESEARCH_QUESTIONS_DELIMITER = "\n## Research Questions\n"
+INPUT_METADATA_FILENAME = "README.md"
 
 github_client = Github(GITHUB_API_KEY)
-repo = github_client.get_repo(REPO_NAME)
 
 
-def fetch_existing_file_from_github(path: str) -> Optional[ContentFile]:
+def fetch_existing_file_from_github(
+    path: str, repo
+) -> Optional[ContentFile | List[ContentFile]]:
     try:
         file = repo.get_contents(path)
     except UnknownObjectException:
@@ -35,7 +38,7 @@ def fetch_existing_file_from_github(path: str) -> Optional[ContentFile]:
     return file
 
 
-def write_existing_pipeline_data_to_state(data: Dict[Any, Any]) -> None:
+def pipeline_config_to_session_state(data: Dict[Any, Any]) -> None:
     docs = f'{data["doc"]["description"]}\n{data["doc"]["doc"]}'.split(
         RESEARCH_QUESTIONS_DELIMITER
     )
@@ -80,8 +83,18 @@ def state_steps_to_module_config() -> List[DummyModuleConfig]:
     return steps_config
 
 
+def session_state_to_pipeline_config() -> PipelineConfig:
+    return DummyModuleConfig.create_pipeline_config(
+        st.session_state["workflow_title"],
+        f"{st.session_state['workflow_description']}{RESEARCH_QUESTIONS_DELIMITER}{st.session_state['workflow_research']}",
+        st.session_state["contact_email"],
+        *state_steps_to_module_config(),
+    )
+
+
 def write_file_to_github(path: str, data) -> None:
-    existing_file = fetch_existing_file_from_github(path)
+    repo = github_client.get_repo(REPO_NAME)
+    existing_file = fetch_existing_file_from_github(path, repo)
     if existing_file:
         repo.update_file(
             path=existing_file.path,
@@ -103,7 +116,24 @@ def write_file_to_github(path: str, data) -> None:
         )
 
 
-def write_example_data_file_to_github(target_directory: str, files: SomeUploadedFiles):
+def load_and_parse_workflow_file(filepath: str):
+    repo = github_client.get_repo(REPO_NAME)
+    workflow_file = fetch_existing_file_from_github(filepath, repo)
+    if workflow_file:
+        existing_data = json.loads(workflow_file.decoded_content.decode("utf-8"))
+        pipeline_config_to_session_state(existing_data)
+        st.success("Loaded existing workflow")
+    else:
+        st.warning("No saved workflow found")
+
+
+def write_input_metadata_file_to_github(workflow_data_path: str, input_details: str):
+    write_file_to_github(
+        f"{workflow_data_path}/{INPUT_METADATA_FILENAME}", input_details
+    )
+
+
+def write_example_data_files_to_github(target_directory: str, files: SomeUploadedFiles):
     for f in files:
         commit_lfs_file(
             repo=REPO_NAME,
@@ -115,23 +145,23 @@ def write_example_data_file_to_github(target_directory: str, files: SomeUploaded
         )
 
 
-def load_and_parse_file(filepath: str):
-    workflow_file = fetch_existing_file_from_github(filepath)
-    if workflow_file:
-        existing_data = json.loads(workflow_file.decoded_content.decode("utf-8"))
-        write_existing_pipeline_data_to_state(existing_data)
-        st.success("Loaded existing workflow")
-    else:
-        st.warning("No saved workflow found")
+def list_input_data_dir(directory_path: str) -> List[str]:
+    """Return a list of markdown bullet points for each file in the input data directory for that workflow"""
+    repo = github_client.get_repo(REPO_NAME)
+    response = fetch_existing_file_from_github(directory_path, repo)
+    if response:
+        return [
+            f"- {f.path.replace(directory_path + '/', '')}\n"
+            for f in response
+            if f.path.replace(directory_path + "/", "") != INPUT_METADATA_FILENAME
+        ]
+    return []
 
 
-def serialize_workflow_to_github(filepath: str):
-    pc = DummyModuleConfig.create_pipeline_config(
-        st.session_state["workflow_title"],
-        f"{st.session_state['workflow_description']}{RESEARCH_QUESTIONS_DELIMITER}{st.session_state['workflow_research']}",
-        st.session_state["contact_email"],
-        *state_steps_to_module_config(),
+def input_metadata_to_session_state(directory_path: str) -> None:
+    repo = github_client.get_repo(REPO_NAME)
+    response: Optional[ContentFile] = fetch_existing_file_from_github(
+        directory_path + "/" + INPUT_METADATA_FILENAME, repo
     )
-    # st.kiara.pipeline_graph(pc) #  TODO connect step input to previous step output in order to make the graph useful?
-    write_file_to_github(filepath, json.dumps(pc.dict(), indent=2))
-    # TODO is there a way to exclude some of the duplicated info about steps here?
+    if response:
+        st.session_state["input_details"] = response.decoded_content.decode("utf-8")

--- a/util.py
+++ b/util.py
@@ -9,6 +9,8 @@ from boltons.strutils import slugify
 from github import Github, UnknownObjectException
 from github.ContentFile import ContentFile
 from github.InputGitAuthor import InputGitAuthor
+from githublfs import commit_lfs_file
+from streamlit.elements.file_uploader import SomeUploadedFiles
 
 from kiara_plugin.streamlit.modules import DummyModuleConfig
 
@@ -101,7 +103,19 @@ def write_file_to_github(path: str, data) -> None:
         )
 
 
-def load_and_parse_file(filepath):
+def write_example_data_file_to_github(target_directory: str, files: SomeUploadedFiles):
+    for f in files:
+        commit_lfs_file(
+            repo=REPO_NAME,
+            token=GITHUB_API_KEY,
+            branch=BRANCH,
+            path=f"{target_directory}/{f.name}",
+            content=f.getvalue(),
+            message=f"add input data: {f.name}",
+        )
+
+
+def load_and_parse_file(filepath: str):
     workflow_file = fetch_existing_file_from_github(filepath)
     if workflow_file:
         existing_data = json.loads(workflow_file.decoded_content.decode("utf-8"))

--- a/workflows.py
+++ b/workflows.py
@@ -60,6 +60,37 @@ else:
         key="workflow_research",
         height=100,
     )
+    st.write("## Input data samples")
+
+    input_details = st.text_area(
+        label="Tell us about the input data for your workflow", key="input_details"
+    )
+    with st.expander("What should I write here?"):
+        st.write(
+            """Tell us as much as you can about the data you use as input for your workflow. This could include things like:
+- Where does the data come from?
+- What license does it have?
+- What file format(s) is it in? How big are the files, how many files?
+- What structural properties do these files have?
+    - do the filenames mean something?
+    - if there's a spreadsheet, what are the column headers?
+    - if it represents network data, how many nodes and edges, does it have self-loops etc"""
+        )
+
+    st.write(
+        "If the data you use as input to your workflows is freely licensed, please upload a sample of it here."
+    )
+    input_data = st.file_uploader("Choose file(s)", accept_multiple_files=True)
+
+    save_input_data = st.button("Save input data information", type="primary")
+    if save_input_data:
+        toast = st.empty()
+        toast.info("Saving...")
+        write_file_to_github(f"{workflow_data_path}/README.md", input_details)
+        write_example_data_file_to_github(workflow_data_path, input_data)
+        toast.success("Saved input data information")
+        time.sleep(3)
+        toast.write("")
 
     st.write("## Workflow steps")
     st.write("Describe the individual steps you do in your workflow at the moment.")
@@ -118,31 +149,3 @@ else:
         "Don't refresh the page or close this tab until you've saved your workflow!"
     )
 
-    st.write("## Input data samples")
-    st.write(
-        """Tell us as much as you can about the data you use as input for your workflow. This could include things like:
-- Where does the data come from?
-- What license does it have?
-- What file format(s) is it in? How big are the files, how many files?
-- What structural properties do these files have?
-    - do the filenames mean something?
-    - if there's a spreadsheet, what are the column headers?
-    - if it represents network data, how many nodes and edges, does it have self-loops etc"""
-    )
-    input_details = st.text_area(
-        label="Workflow input data details", key="input_details"
-    )
-    st.write(
-        "If the data you use as input to your workflows is freely licensed, please upload a sample of it here."
-    )
-    input_data = st.file_uploader("Choose file(s)", accept_multiple_files=True)
-
-    save_input_data = st.button("Save input data information", type="primary")
-    if save_input_data:
-        toast = st.empty()
-        toast.info("Saving...")
-        write_file_to_github(f"{workflow_data_path}/README.md", input_details)
-        write_example_data_file_to_github(workflow_data_path, input_data)
-        toast.success("Saved input data information")
-        time.sleep(3)
-        toast.write("")

--- a/workflows.py
+++ b/workflows.py
@@ -37,11 +37,13 @@ workflow_title = st.text_input(
 if not (workflow_title and contact_email):
     st.info("Please enter your email and workflow title, then press enter.")
 else:
-    workflow_path = f"{contact_email}/{slugify(workflow_title)}/pipeline.json"
+    workflow_base_path = f"{contact_email}/{slugify(workflow_title)}"
+    workflow_pipeline_path = f"{workflow_base_path}/pipeline.json"
+    workflow_data_path = f"{workflow_base_path}/data"
 
     edit = st.button("load existing workflow for editing?")
     if edit:
-        load_and_parse_file(workflow_path)
+        load_and_parse_file(workflow_pipeline_path)
 
     st.text_area(
         "Describe what your workflow achieves",
@@ -102,8 +104,7 @@ else:
 
     create = st.button("Save workflow", type="primary")
     if create:
-        serialize_workflow_to_github(workflow_path)
-        st.write(st.session_state)
+        serialize_workflow_to_github(workflow_pipeline_path)
         toast = st.empty()
         toast.success("Saved workflow")
         time.sleep(3)

--- a/workflows.py
+++ b/workflows.py
@@ -8,8 +8,12 @@ from kiara.api import KiaraAPI
 
 import kiara_plugin.streamlit as kst
 
-from util import load_and_parse_file, serialize_workflow_to_github
-
+from util import (
+    load_and_parse_file,
+    serialize_workflow_to_github,
+    write_file_to_github,
+    write_example_data_file_to_github,
+)
 
 kst.init()
 
@@ -113,3 +117,32 @@ else:
     st.warning(
         "Don't refresh the page or close this tab until you've saved your workflow!"
     )
+
+    st.write("## Input data samples")
+    st.write(
+        """Tell us as much as you can about the data you use as input for your workflow. This could include things like:
+- Where does the data come from?
+- What license does it have?
+- What file format(s) is it in? How big are the files, how many files?
+- What structural properties do these files have?
+    - do the filenames mean something?
+    - if there's a spreadsheet, what are the column headers?
+    - if it represents network data, how many nodes and edges, does it have self-loops etc"""
+    )
+    input_details = st.text_area(
+        label="Workflow input data details", key="input_details"
+    )
+    st.write(
+        "If the data you use as input to your workflows is freely licensed, please upload a sample of it here."
+    )
+    input_data = st.file_uploader("Choose file(s)", accept_multiple_files=True)
+
+    save_input_data = st.button("Save input data information", type="primary")
+    if save_input_data:
+        toast = st.empty()
+        toast.info("Saving...")
+        write_file_to_github(f"{workflow_data_path}/README.md", input_details)
+        write_example_data_file_to_github(workflow_data_path, input_data)
+        toast.success("Saved input data information")
+        time.sleep(3)
+        toast.write("")


### PR DESCRIPTION
Add a section of the workflow form that allows users to write some information about their input data, and optionally upload sample files. These are written under the `data` directory next to the relevant pipeline file, with text information in the `README.md` file and any files keeping their existing filenames. 

All uploaded files except the readme use `git lfs`, via the [`githublfs`](https://pypi.org/project/githublfs/) library to handle some complicated API calls. This library warns that it is experimental, but so is all of the code in this repo so I'm not too worried.

You can see an example of the output of the app for a specific workflow [here](https://github.com/caro401/kiara-workflow-test/tree/main/hi%40caro.fyi/test) - note that the txt file in `/data` says 'Stored with Git LFS'